### PR TITLE
H4C-246: Error handling in the JSONRpc module

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3,7 +3,7 @@ import * as request from "supertest";
 import { Test } from "@nestjs/testing";
 import { INestMicroservice } from "@nestjs/common";
 
-import { TestService, CodedRpcException } from "./test-handler";
+import { TestService } from "./test-handler";
 import { JSONRPCServer } from ".";
 
 describe("json-rpc-e2e", () => {
@@ -48,19 +48,6 @@ describe("json-rpc-e2e", () => {
       .send({ method: "test.testError", params: { data: "hi" } })
       .expect(403)
       .expect(errorObj);
-
-    // The testing with expect(req).rejects doesn't work
-
-    // const req = request(server.server)
-    //   .post("/rpc/v1")
-    //   .send({ method: "test.testError", params: { data: "hi" } });
-
-    // expect(req).rejects.toEqual(
-    //   new CodedRpcException("RPC EXCEPTION", 403, {
-    //     fromService: "Test Service",
-    //     params: { data: "hi" }
-    //   })
-    //);
   });
 
   afterAll(async () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3,7 +3,7 @@ import * as request from "supertest";
 import { Test } from "@nestjs/testing";
 import { INestMicroservice } from "@nestjs/common";
 
-import { TestService } from "./test-handler";
+import { TestService, CodedRpcException } from "./test-handler";
 import { JSONRPCServer } from ".";
 
 describe("json-rpc-e2e", () => {
@@ -32,6 +32,35 @@ describe("json-rpc-e2e", () => {
       .expect({
         data: "hi"
       });
+  });
+
+  it(`should throw an error on /rpc/v1/ test.testError (POST)`, () => {
+    const errorObj = {
+      message: "RPC EXCEPTION",
+      code: 403,
+      data: {
+        fromService: "Test Service",
+        params: { data: "hi" }
+      }
+    };
+    return request(server.server)
+      .post("/rpc/v1")
+      .send({ method: "test.testError", params: { data: "hi" } })
+      .expect(403)
+      .expect(errorObj);
+
+      // The testing with expect(req).rejects doesn't work
+
+    // const req = request(server.server)
+    //   .post("/rpc/v1")
+    //   .send({ method: "test.testError", params: { data: "hi" } });
+
+    // expect(req).rejects.toEqual(
+    //   new CodedRpcException("RPC EXCEPTION", 403, {
+    //     fromService: "Test Service",
+    //     params: { data: "hi" }
+    //   })
+    );
   });
 
   afterAll(async () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -49,7 +49,7 @@ describe("json-rpc-e2e", () => {
       .expect(403)
       .expect(errorObj);
 
-      // The testing with expect(req).rejects doesn't work
+    // The testing with expect(req).rejects doesn't work
 
     // const req = request(server.server)
     //   .post("/rpc/v1")
@@ -60,7 +60,7 @@ describe("json-rpc-e2e", () => {
     //     fromService: "Test Service",
     //     params: { data: "hi" }
     //   })
-    );
+    //);
   });
 
   afterAll(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,8 @@ export interface JSONRPCServerOptions {
    */
   hostname?: string;
   /*
-      * The path at which the JSON RPC endpoint should be mounted
-      */
+   * The path at which the JSON RPC endpoint should be mounted
+   */
   path: string;
 }
 
@@ -73,8 +73,13 @@ export class JSONRPCServer extends Server implements CustomTransportStrategy {
           error => ({ error })
         );
 
+      console.log(response);
+
       if ("error" in response) {
-        res.status(500).json({ error: response.error.message })
+        let resp = { code: 500, message: response.error.message, data: undefined };
+        if ("code" in response.error) resp.code = response.error.code;
+        if ("data" in response.error) resp.data = response.error.data;
+        res.status(resp.code).json(resp);
       } else {
         res.status(200).json(response.value);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as express from "express";
 import * as http from "http";
 
-import { Server, CustomTransportStrategy } from "@nestjs/microservices";
+import { Server, CustomTransportStrategy, RpcException } from "@nestjs/microservices";
 import { Injectable, Controller } from "@nestjs/common";
 import { MessagePattern } from "@nestjs/microservices";
 
@@ -73,8 +73,6 @@ export class JSONRPCServer extends Server implements CustomTransportStrategy {
           error => ({ error })
         );
 
-      console.log(response);
-
       if ("error" in response) {
         let resp = { code: 500, message: response.error.message, data: undefined };
         if ("code" in response.error) resp.code = response.error.code;
@@ -99,5 +97,11 @@ export class JSONRPCServer extends Server implements CustomTransportStrategy {
   public async close() {
     await invokeAsync(cb => this.server && this.server.close(cb));
     // do nothing, maybe block further requests
+  }
+}
+
+export class CodedRpcException extends RpcException {
+  constructor(message: string, public code: number = 500, public data: any = {}) {
+    super({ message, code, data });
   }
 }

--- a/src/test-handler.ts
+++ b/src/test-handler.ts
@@ -13,6 +13,7 @@ import {
 } from "@nestjs/common";
 
 import { JSONRpcService } from ".";
+import { RpcException } from "@nestjs/microservices";
 
 const initialModuleState = {
   pipeCalled: false,
@@ -76,5 +77,21 @@ export class TestService {
   public async invoke(params: any) {
     console.log("Invoke WAS called");
     return params;
+  }
+
+  @UsePipes(TestPipe)
+  @UseInterceptors(TestInterceptor)
+  @UseGuards(TestGuard)
+  public async testError(params: any) {
+    console.log("Throw an error !!!");
+
+    // construct the error object with some data inside
+    throw new CodedRpcException("RPC EXCEPTION", 403, { fromService: "Test Service", params });
+  }
+}
+
+export class CodedRpcException extends RpcException {
+  constructor(message: string, public code: number = 500, public data: any = {}) {
+    super({ message, code, data });
   }
 }

--- a/src/test-handler.ts
+++ b/src/test-handler.ts
@@ -12,8 +12,7 @@ import {
   Scope
 } from "@nestjs/common";
 
-import { JSONRpcService } from ".";
-import { RpcException } from "@nestjs/microservices";
+import { JSONRpcService, CodedRpcException } from ".";
 
 const initialModuleState = {
   pipeCalled: false,
@@ -83,15 +82,7 @@ export class TestService {
   @UseInterceptors(TestInterceptor)
   @UseGuards(TestGuard)
   public async testError(params: any) {
-    console.log("Throw an error !!!");
-
     // construct the error object with some data inside
     throw new CodedRpcException("RPC EXCEPTION", 403, { fromService: "Test Service", params });
-  }
-}
-
-export class CodedRpcException extends RpcException {
-  constructor(message: string, public code: number = 500, public data: any = {}) {
-    super({ message, code, data });
   }
 }


### PR DESCRIPTION
This PR examines the approaches for throwing an error in the rpc methods .

1. The RPC methods will throw CodedRpcException.
2. The exception will be intercepted in the json rpc handler and it will be return as resolved promise with the error code and error object with message.

However the unit tests will need to test for errors like this:
```
return request(server.server)
      .post("/rpc/v1")
      .send({ method: "test.testError", params: { data: "hi" } })
      .expect(403)
      .expect(errorObj);
```
instead of testing the promise to fail like this:
`expect(req).rejects.toEqual`

We still need to see if and how we will use global exception handlers and how we will audit the errors which needs to be audited.

p.s Some of the console logs are left on purpose for testing.