### PR TITLE
Pass an HTTP Server adapter instead of using express directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,18 @@ Currently uses HTTP as the transport layer, with plans to add other options as t
 
 ## Usage example
 
-Initialize similar to a regular microservice used in a hybrid application, but pass a `JsonRpcService` as the strategy option:
+Initialize similar to a regular microservice, but pass a `JsonRpcService` as the strategy option:
 
 ```typescript
+const app = await NestFactory.createMicroservice(ApplicationModule, {
 const app = NestFactory.create(ApplicationModule);
 app.connectMicroservice({
   strategy: new JsonRpcServer({
     path: "/rpc/v1",
+    port: 8080
     server: app.getHttpAdapter()
   })
 });
-
 await app.startAllMicroservicesAsync();
 await app.listenAsync(3000);
 ```
@@ -65,6 +66,22 @@ For the different types of decorators, see:
 - Access control checks, permission, role checks - use [NestJS Guards](https://docs.nestjs.com/guards)
 - Transforming errors into appropriate CodedRpcExceptions (see below) - use [NestJS Exception Filters](https://docs.nestjs.com/exception-filters)
 - All other aspect oriented programming bits (logging, tracing performance measurements etc): use [NestJS Interceptors](https://docs.nestjs.com/interceptors)
+
+### Hybrid Mode
+Running in Hybrid Mode allows you to use a JSON-RPC endpoint alongside an existing Nest.JS application, using the same port. This could be used to run side-by-side with a Healthcheck endpoint, for example. All the decorators remain the same, but the initialization of the microservice should be modified as follows:
+
+```typescript
+const app = NestFactory.create(ApplicationModule);
+app.connectMicroservice({
+  strategy: new JsonRpcServer({
+    path: "/rpc/v1",
+    server: app.getHttpAdapter()
+  })
+});
+
+await app.startAllMicroservicesAsync();
+await app.listenAsync(3000);
+```
 
 ### Client
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
     "test:cov": "jest --coverage"
   },
   "dependencies": {
-    "@nestjs/core": "^7.5.1",
     "@nestjs/common": "^7.4.4",
+    "@nestjs/core": "^7.5.1",
     "@nestjs/microservices": "^7.5.5",
+    "@nestjs/platform-express": "^7.5.5",
     "axios": "^0.19.2",
     "express": "^4.17.1",
     "reflect-metadata": "^0.1.13"
@@ -31,7 +32,7 @@
     "jest": "^25.1.0",
     "prettier": "^1.15.3",
     "rxjs": "^6.0.0",
-    "supertest": "^4.0.2",
+    "supertest": "^6.0.1",
     "ts-jest": "25.2.1",
     "ts-node": "8.6.2",
     "typescript": "3.8.3"

--- a/src/client-proxy.ts
+++ b/src/client-proxy.ts
@@ -1,6 +1,5 @@
 import { ClientProxy } from "@nestjs/microservices";
 import axios from "axios";
-import { response } from "express";
 import { CodedRpcException } from "./coded-error";
 import { JsonRpcResponse } from "./transport-types";
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,80 +1,147 @@
+import * as request from 'supertest';
+
 import { Test } from "@nestjs/testing";
-import { INestMicroservice } from "@nestjs/common";
+import { INestApplication, INestMicroservice } from "@nestjs/common";
 
 import { ITestClientService, TestService } from "./test-handler";
 import { JsonRpcServer, JsonRpcClient, CodedRpcException } from ".";
 
 describe("json-rpc-e2e", () => {
-  let app: INestMicroservice;
+  let microservice: INestMicroservice;
+  let app: INestApplication;
   let server: JsonRpcServer;
   let client: JsonRpcClient;
   let clientWithoutMetadata: JsonRpcClient;
   let service: ITestClientService;
   let unauthorizedService: ITestClientService;
 
-  beforeAll(async () => {
-    let moduleRef = await Test.createTestingModule({
-      controllers: [TestService]
-    }).compile();
+  describe('standalone', () => {
+    beforeAll(async () => {
+      let moduleRef = await Test.createTestingModule({
+        controllers: [TestService]
+      }).compile();
 
-    server = new JsonRpcServer({
-      path: "/rpc/v1",
-      port: 8080
+      server = new JsonRpcServer({
+        path: "/rpc/v1",
+        port: 8080
+      });
+
+      client = new JsonRpcClient("http://localhost:8080/rpc/v1", {
+        Authorization: "Bearer xyz"
+      });
+
+      clientWithoutMetadata = new JsonRpcClient("http://localhost:8080/rpc/v1");
+
+      service = client.getService<ITestClientService>("test");
+
+      unauthorizedService = clientWithoutMetadata.getService<ITestClientService>("test");
+
+      microservice = moduleRef.createNestMicroservice({ strategy: server });
+      await microservice.listenAsync();
     });
 
-    client = new JsonRpcClient("http://localhost:8080/rpc/v1", {
-      Authorization: "Bearer xyz"
+    it(`should make an RPC call with the JsonRpcClient`, async () => {
+      let res = await service.invokeClientService({ test: "hi" });
+      expect(res).toStrictEqual({ test: "hi" });
     });
 
-    clientWithoutMetadata = new JsonRpcClient("http://localhost:8080/rpc/v1");
-
-    service = client.getService<ITestClientService>("test");
-
-    unauthorizedService = clientWithoutMetadata.getService<ITestClientService>("test");
-
-    app = moduleRef.createNestMicroservice({ strategy: server });
-    await app.listenAsync();
-  });
-
-  it(`should make and RPC call with the JsonRpcClient`, async () => {
-    let res = await service.invokeClientService({ test: "hi" });
-    expect(res).toStrictEqual({ test: "hi" });
-  });
-
-  it(`should fail to make a request with an unauthorized JsonRpcClient`, async () => {
-    let result = unauthorizedService.invokeClientService({ test: "hi" });
-    await expect(result).rejects.toThrowError("Forbidden resource");
-  });
-
-  it(`should return an error and check error data from JsonRpcClient call`, async () => {
-    const expectedCodedException = new CodedRpcException("RPC EXCEPTION", 403, {
-      fromService: "Test Service",
-      params: { data: "hi" }
+    it(`should fail to make a request with an unauthorized JsonRpcClient`, async () => {
+      let result = unauthorizedService.invokeClientService({ test: "hi" });
+      await expect(result).rejects.toThrowError("Forbidden resource");
     });
 
-    const resp = service.testError({ errorTest: "hi" });
-    await expect(resp).rejects.toThrowError(expectedCodedException);
+    it(`should return an error and check error data from JsonRpcClient call`, async () => {
+      const expectedCodedException = new CodedRpcException("RPC EXCEPTION", 403, {
+        fromService: "Test Service",
+        params: { data: "hi" }
+      });
+
+      const resp = service.testError({ errorTest: "hi" });
+      await expect(resp).rejects.toThrowError(expectedCodedException);
+    });
+
+    it(`should fail to invoke unexposed methods`, async () => {
+      const expectedCodedException = new CodedRpcException("Method not found: test.notExposed", 404);
+      const resp = service.notExposed({ test: "data" });
+      await expect(resp).rejects.toThrowError(expectedCodedException);
+    });
+
+    it(`should see unrecognized errors`, async () => {
+      const expectedCodedException = new CodedRpcException("Internal server error");
+      const resp = service.unrecognizedError({});
+      await expect(resp).rejects.toThrowError(expectedCodedException);
+    });
+
+    it(`should inject the context`, async () => {
+      const expectedCodedException = new CodedRpcException("Internal server error");
+      const resp = await service.injectContext({});
+      expect(resp.key).toEqual("Bearer xyz");
+    });
+
+    afterAll(async () => {
+      await microservice.close();
+    });
   });
 
-  it(`should fail to invoke unexposed methods`, async () => {
-    const expectedCodedException = new CodedRpcException("Method not found: test.notExposed", 404);
-    const resp = service.notExposed({ test: "data" });
-    await expect(resp).rejects.toThrowError(expectedCodedException);
-  });
+  describe('hybrid', () => {
+    beforeAll(async () => {
+      let moduleRef = await Test.createTestingModule({
+        controllers: [TestService]
+      }).compile();
+    
+      app = moduleRef.createNestApplication();
 
-  it(`should see unrecognized errors`, async () => {
-    const expectedCodedException = new CodedRpcException("Internal server error");
-    const resp = service.unrecognizedError({});
-    await expect(resp).rejects.toThrowError(expectedCodedException);
-  });
+      server = new JsonRpcServer({
+        path: '/rpc',
+        adapter: app.getHttpAdapter(),
+      });
 
-  it(`should inject the context`, async () => {
-    const expectedCodedException = new CodedRpcException("Internal server error");
-    const resp = await service.injectContext({});
-    expect(resp.key).toEqual("Bearer xyz");
-  });
+      app.connectMicroservice({ strategy: server });
 
-  afterAll(async () => {
-    await app.close();
+      await app.startAllMicroservicesAsync();
+      await app.init();
+    });
+
+    it('should invoke RPC methods on incoming HTTP requests', async () => {
+      await request(app.getHttpServer())
+        .post('/rpc')
+        .set('Authorization', 'Bearer xyz')
+        .send({
+          jsonrpc: '2.0',
+          method: 'test.invokeClientService',
+          id: '1',
+          params: {
+            test: 'hi',
+          },
+        })
+        .expect({
+          jsonrpc: '2.0',
+          id: '1',
+          result: { test: 'hi' }
+        });
+    });
+
+    it('should wrap json-rpc errors in http 200', async () => {
+      await request(app.getHttpServer())
+      .post('/rpc')
+      .set('Authorization', 'Bearer xyz')
+      .send({
+        jsonrpc: '2.0',
+        method: 'test.notExposed',
+        id: '1',
+        params: {
+          test: 'hi',
+        },
+      })
+      .expect({
+        jsonrpc: '2.0',
+        id: '1',
+        error: { 
+          code: 404, 
+          data: {}, 
+          message: 'Method not found: test.notExposed',
+        }
+      });
+    });
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,10 @@
+import * as bodyParser from "body-parser";
 import * as express from "express";
 import * as http from "http";
 
-import { Server, CustomTransportStrategy, RpcException } from "@nestjs/microservices";
-import { Injectable, Controller } from "@nestjs/common";
-import { MessagePattern } from "@nestjs/microservices";
+import { Server, CustomTransportStrategy } from "@nestjs/microservices";
+import { HttpServer } from "@nestjs/common";
 
-import { invokeAsync } from "./util";
 import { JsonRpcResponse } from "./transport-types";
 import { CodedRpcException } from "./coded-error";
 
@@ -17,19 +16,16 @@ export class JsonRpcContext {
   }
 }
 
-export interface JsonRpcServerOptions {
+interface JsonRpcServerOptions {
   /**
-   * Listening port for the HTTP server
-   */
-  port: number;
-  /**
-   * Listening host (optional, defaults to any)
-   */
-  hostname?: string;
-  /*
    * The path at which the JSON RPC endpoint should be mounted
    */
   path: string;
+
+  /**
+   * The HTTP Server provided by the Nest runtime
+   */
+  server: HttpServer;
 }
 
 /**
@@ -66,11 +62,10 @@ export class JsonRpcServer extends Server implements CustomTransportStrategy {
   }
 
   public async listen(callback: () => void) {
-    let app = express();
+    let app = this.options.server ?? express();
+    app.use(bodyParser.json());
 
-    app.post(this.options.path, express.json(), async (req, res) => {
-      // let handlers = this.getHandlers();
-
+    app.post(this.options.path, async (req, res) => {
       let handler = this.getHandlerByPattern(req.body.method);
 
       if (handler == null) {
@@ -78,7 +73,7 @@ export class JsonRpcServer extends Server implements CustomTransportStrategy {
         return res.status(200).json(serializeResponse(req.body.id, { error }));
       }
 
-      let context = new JsonRpcContext(req, app);
+      let context = new JsonRpcContext(req, app.getHttpServer());
 
       let observableResult = this.transformToObservable(await handler(req.body.params, context));
       let promiseResult = observableResult.toPromise();
@@ -91,19 +86,10 @@ export class JsonRpcServer extends Server implements CustomTransportStrategy {
       res.status(200).json(serializeResponse(req.body.id, response));
     });
 
-    await invokeAsync(cb => {
-      if (this.options.hostname != null) {
-        this.server = app.listen(this.options.port, this.options.hostname, cb);
-      } else {
-        this.server = app.listen(this.options.port, cb);
-      }
-    });
-
     callback();
   }
 
   public async close() {
-    await invokeAsync(cb => this.server && this.server.close(cb));
     // do nothing, maybe block further requests
   }
 }


### PR DESCRIPTION
Passing an HTTP Server rather than using express directly decouples the library from express, allowing consumers to use different HTTP implementations. This is useful in a few scenarios:
 
 - If a consumer wants to use a different HTTP library (e.g. Fastify) they won't need both that and express.
  - Consumers can re-use the existing Nest HTTP server, so JSON-RPC endpoints can live on the same port as other Nest endpoints which don't use JSON-RPC (e.g. healthchecks and metrics)
  - Tests can use mock HTTP server implementations like supertest, rather than using a real HTTP server. This is faster, and aids in test isolation (by avoiding port conflicts).