### PR TITLE
Add support for type-safe custom context metadata

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -88,6 +88,11 @@ describe("json-rpc-e2e", () => {
       expect(resp.key).toEqual("Bearer xyz");
     });
 
+    it("should return custom data stored in the context", async () => {
+      const resp = await service.getUserInfo({});
+      expect(resp?.name?.length).toBeGreaterThan(0);
+    });
+
     afterAll(async () => {
       await microservice.close();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from "./client-proxy";
 export * from "./coded-error";
 export * from "./decorators";
 export * from "./convert-types";
+export { TypesafeKey } from "./typesafe-map";

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,36 +10,6 @@ import { HttpServer } from "@nestjs/common";
 import { invokeAsync } from "./util";
 import { TypesafeMap } from "./typesafe-map";
 
-interface HybridJsonRpcServerOptions {
-  /**
-   * The path at which the JSON RPC endpoint should be mounted
-   */
-  path: string;
-
-  /**
-   * The HTTP Server provided by the Nest runtime
-   */
-  adapter: HttpServer<any, any>;
-}
-
-interface StandaloneJsonRpcServerOptions {
-  /**
-   * Listening port for the HTTP server
-   */
-  port: number;
-
-  /**
-   * Listening host (optional, defaults to any)
-   */
-  hostname?: string;
-  /*
-   * The path at which the JSON RPC endpoint should be mounted
-   */
-  path: string;
-}
-
-export type JsonRpcServerOptions = HybridJsonRpcServerOptions | StandaloneJsonRpcServerOptions;
-
 export class JsonRpcContext {
   private _customData = new TypesafeMap();
 
@@ -85,6 +55,36 @@ export class JsonRpcContext {
     return this.req.body.params;
   }
 }
+
+interface HybridJsonRpcServerOptions {
+  /**
+   * The path at which the JSON RPC endpoint should be mounted
+   */
+  path: string;
+
+  /**
+   * The HTTP Server provided by the Nest runtime
+   */
+  adapter: HttpServer<any, any>;
+}
+
+interface StandaloneJsonRpcServerOptions {
+  /**
+   * Listening port for the HTTP server
+   */
+  port: number;
+
+  /**
+   * Listening host (optional, defaults to any)
+   */
+  hostname?: string;
+  /*
+   * The path at which the JSON RPC endpoint should be mounted
+   */
+  path: string;
+}
+
+export type JsonRpcServerOptions = HybridJsonRpcServerOptions | StandaloneJsonRpcServerOptions;
 
 /**
  * Helper to serialize JSONRPC responses

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,18 +8,7 @@ import { JsonRpcResponse } from "./transport-types";
 import { CodedRpcException } from "./coded-error";
 import { HttpServer } from "@nestjs/common";
 import { invokeAsync } from "./util";
-
-export class JsonRpcContext {
-  constructor(private req: express.Request, private server: express.Application) {}
-
-  getMetadataByKey(metadataKey: string): string | undefined {
-    return this.req.get(metadataKey);
-  }
-
-  getParams(): unknown {
-    return this.req.body.params;
-  }
-}
+import { TypesafeMap } from "./typesafe-map";
 
 interface HybridJsonRpcServerOptions {
   /**
@@ -50,6 +39,24 @@ interface StandaloneJsonRpcServerOptions {
 }
 
 export type JsonRpcServerOptions = HybridJsonRpcServerOptions | StandaloneJsonRpcServerOptions;
+
+export class JsonRpcContext {
+  private _customData = new TypesafeMap();
+
+  constructor(private req: express.Request, private server: express.Application) {}
+
+  get customData() {
+    return this._customData;
+  }
+
+  getMetadataByKey(metadataKey: string): string | undefined {
+    return this.req.get(metadataKey);
+  }
+
+  getParams(): unknown {
+    return this.req.body.params;
+  }
+}
 
 /**
  * Helper to serialize JSONRPC responses

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,34 @@ export class JsonRpcContext {
 
   constructor(private req: express.Request, private server: express.Application) {}
 
+  /**
+   * Allows you to access and set custom data into individual remote procedure call contexts
+   * in a type-safe way.
+   *
+   * To use this property, you need to instantiate a TypesafeKey.
+   *
+   * The following example decodes and adds user info to the context. JWT is extracted from
+   * the RPC request metadata (the Authorization header for our HTTP transport)
+   *
+   * ```
+   * import { TypesafeKey } from '@hfour/nestjs-json-rpc'
+   * import { UserInfo } from './my-code';
+   *
+   * const UserInfoKey = new TypesafeKey<UserInfo>('myapp:auth:UserInfo');
+   *
+   * export class TestAuthenticateGuard implements CanActivate {
+   *   public async canActivate(context: ExecutionContext): Promise<boolean> {
+   *     const ctx = context.switchToRpc().getContext<JsonRpcContext>();
+   *     let jwtMetadata = ctx.getMetadataByKey('Authorization');
+   *     if (!jwtMetadata) return false;
+   *     const decoded: Result<UserInfo> = jwt.decodeBearer(jwtMetadata);
+   *     if (decoded.error) return false;
+   *     ctx.customData.set(UserInfo, decoded.result)
+   *     return true;
+   *   }
+   * }
+   * ```
+   */
   get customData() {
     return this._customData;
   }

--- a/src/typesafe-map.spec.ts
+++ b/src/typesafe-map.spec.ts
@@ -1,0 +1,16 @@
+import { TypesafeKey, TypesafeMap } from "./typesafe-map";
+
+const MyKey1 = new TypesafeKey<{ test: string }>("hfour:jsonrpc:mykey1");
+const MyKey2 = new TypesafeKey<{ second: string }>("hfour:jsonrpc:mykey2");
+
+describe("typesafe-map", () => {
+  it("works with typesafe keys", () => {
+    let m = new TypesafeMap();
+
+    m.set(MyKey1, { test: "value" });
+    m.set(MyKey2, { second: "value2" });
+
+    expect(m.get(MyKey1).test).toEqual("value");
+    expect(m.get(MyKey2).second).toEqual("value2");
+  });
+});

--- a/src/typesafe-map.spec.ts
+++ b/src/typesafe-map.spec.ts
@@ -10,7 +10,7 @@ describe("typesafe-map", () => {
     m.set(MyKey1, { test: "value" });
     m.set(MyKey2, { second: "value2" });
 
-    expect(m.get(MyKey1).test).toEqual("value");
-    expect(m.get(MyKey2).second).toEqual("value2");
+    expect(m.get(MyKey1)?.test).toEqual("value");
+    expect(m.get(MyKey2)?.second).toEqual("value2");
   });
 });

--- a/src/typesafe-map.ts
+++ b/src/typesafe-map.ts
@@ -1,5 +1,28 @@
+/**
+ * This class lets you define a type-safe key to use with TypeSafe maps, such as
+ * the RPC context custom data map.
+ *
+ * To use this class, simply instantiate a const key (which you may want to export)
+ *
+ * ```typescript
+ * export const MyExtraInfo =
+ *   new TypesafeKey<ExtraInfoInterface>('myapp:info:ExtraInfo');
+ * ```
+ *
+ * Note that you must take care to use a unique namespace string for the key.
+ *
+ * You can now use the key like so:
+ *
+ * ```typescript
+ * import {MyExtraInfo} from './local-module'
+ *
+ * someMap.set(MyExtraInfo, ObjectOfExtraInfoInterface)
+ *
+ * someMap.get(MyExtraInfo)
+ * // result is of type ExtraInfoInterface | undefined
+ * ```
+ */
 export class TypesafeKey<T> {
-  //@ts-ignore
   private " __brand"!: T;
 
   constructor(private namespace: string) {}
@@ -12,19 +35,36 @@ export class TypesafeKey<T> {
 export class TypesafeMap {
   private map = new Map();
 
-  get<T>(key: TypesafeKey<T>): T {
+  /**
+   * Retreive a typesafe value stored in the map
+   * @param key the {@link TypesafeKey} to retreive a value for
+   */
+  get<T>(key: TypesafeKey<T>): T | undefined {
     return this.map.get(key.toString());
   }
 
+  /**
+   * Set a typesafe value
+   * @param key the {@link TypesafeKey} to set the value for
+   * @param value the actual value. Must be of the correct type
+   */
   set<T>(key: TypesafeKey<T>, value: T) {
     this.map.set(key.toString(), value);
     return this;
   }
 
+  /**
+   * Delete a typesafe value stored in the map
+   * @param key the {@link TypesafeKey} to delete
+   */
   delete<T>(key: TypesafeKey<T>) {
     return this.map.delete(key.toString());
   }
 
+  /**
+   * Check if the map has a value set for the typesafe key
+   * @param key the {@link TypesafeKey} to check
+   */
   has<T>(key: TypesafeKey<T>) {
     return this.map.has(key.toString());
   }

--- a/src/typesafe-map.ts
+++ b/src/typesafe-map.ts
@@ -1,0 +1,31 @@
+export class TypesafeKey<T> {
+  //@ts-ignore
+  private " __brand"!: T;
+
+  constructor(private namespace: string) {}
+
+  toString() {
+    return this.namespace;
+  }
+}
+
+export class TypesafeMap {
+  private map = new Map();
+
+  get<T>(key: TypesafeKey<T>): T {
+    return this.map.get(key.toString());
+  }
+
+  set<T>(key: TypesafeKey<T>, value: T) {
+    this.map.set(key.toString(), value);
+    return this;
+  }
+
+  delete<T>(key: TypesafeKey<T>) {
+    return this.map.delete(key.toString());
+  }
+
+  has<T>(key: TypesafeKey<T>) {
+    return this.map.has(key.toString());
+  }
+}


### PR DESCRIPTION
With this PR, the JsonRpcContext gains a new property called `customData`. Contextual data pertaining to a single remote procedure call (a single "request") can be stored within this property.

To use this property, you need to instantiate a TypesafeKey.

The following example decodes and adds user info to the context. JWT is extracted from
the RPC request metadata (the Authorization header for our HTTP transport)

```typescript
import { TypesafeKey } from '@hfour/nestjs-json-rpc'
import { UserInfo } from './my-code';

export const UserInfoKey = new TypesafeKey<UserInfo>('myapp:auth:UserInfo');

export class TestAuthenticateGuard implements CanActivate {
  public async canActivate(context: ExecutionContext): Promise<boolean> {
    const ctx = context.switchToRpc().getContext<JsonRpcContext>();
    let jwtMetadata = ctx.getMetadataByKey('Authorization');
    if (!jwtMetadata) return false;
    const decoded: Result<UserInfo> = jwt.decodeBearer(jwtMetadata);
    if (decoded.error) return false;
    ctx.customData.set(UserInfoKey, decoded.result)
    return true;
  }
}
```

Then you can read it by injecting the context in the RPC method:

```typescript
  @UseGuards(TestAuthenticateGuard)
  @RpcMethod()
  public async getUserInfo(params: {}, @Ctx() ctx: JsonRpcContext) {
    const userData = ctx.customData.get(UserInfo);
    return Promise.resolve(data?.name);
  }
```

Or you could read the data from another guard, pipe or interceptor.

Note that the user is responsible for managing the key space of custom data and ensuring there are no name conflicts.

Looking for feedback on the design