### PR TITLE
Service Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Decorate your controllers with the `@RpcService` and `@RpcMethod` decorators:
 @RpcService({
   namespace: "test"
 })
-export class TestService implements ServiceImplementation<ITestService> {
+export class TestController implements ControllerImplementation<ITestService> {
   @RpcMethod()
   public async myMethod(params: any) {
     console.log("The method called was test.myMethod");

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Decorate your controllers with the `@RpcService` and `@RpcMethod` decorators:
 @RpcService({
   namespace: "test"
 })
-export class TestService implements ITestService {
+export class TestService implements ServiceImplementation<ITestService> {
   @RpcMethod()
   public async myMethod(params: any) {
     console.log("The method called was test.myMethod");

--- a/src/client-proxy.ts
+++ b/src/client-proxy.ts
@@ -76,9 +76,21 @@ export class JsonRpcClient extends ClientProxy {
   }
 }
 export type ServiceClient<Service> = {
-  [MethodName in keyof Service]: Service[MethodName] extends (params: any) => Promise<any>
-    ? Service[MethodName]
-    : Service[MethodName] extends (params: infer Params) => infer ReturnType
-    ? (params: Params) => Promise<ReturnType>
+  [MethodName in keyof Service]: Service[MethodName] extends (
+    params: infer Params,
+    ...injections: any
+  ) => infer ReturnType
+    ? (params: Params) => ReturnType extends Promise<any> ? ReturnType : Promise<ReturnType>
+    : never;
+};
+
+export type ServiceImplementation<Service> = {
+  [MethodName in keyof Service]: Service[MethodName] extends (
+    params: infer Params
+  ) => infer ReturnType
+    ? (
+        params: Params,
+        ...injections: any
+      ) => ReturnType extends Promise<any> ? ReturnType : Promise<ReturnType>
     : never;
 };

--- a/src/client-proxy.ts
+++ b/src/client-proxy.ts
@@ -84,13 +84,3 @@ export type ServiceClient<Service> = {
     : never;
 };
 
-export type ServiceImplementation<Service> = {
-  [MethodName in keyof Service]: Service[MethodName] extends (
-    params: infer Params
-  ) => infer ReturnType
-    ? (
-        params: Params,
-        ...injections: any
-      ) => ReturnType extends Promise<any> ? ReturnType : Promise<ReturnType>
-    : never;
-};

--- a/src/client-proxy.ts
+++ b/src/client-proxy.ts
@@ -83,4 +83,3 @@ export type ServiceClient<Service> = {
     ? (params: Params) => ReturnType extends Promise<any> ? ReturnType : Promise<ReturnType>
     : never;
 };
-

--- a/src/convert-types.ts
+++ b/src/convert-types.ts
@@ -5,3 +5,9 @@ export type RpcController<T> = {
     ? (params: U, ctx: JsonRpcContext) => Ret
     : never;
 };
+
+export type ControllerImplementation<T> = {
+  [K in keyof T]: T[K] extends (params: infer U) => infer Ret
+    ? (params: U, ...injections: any) => Ret
+    : never;
+};


### PR DESCRIPTION
Updated `ServiceClient` and introduced`ControllerImplementation`.

`ServiceClient` now strips any injections present on the server-side.

`ControllerImplementation` enables adding injections to the base interface. (Only present on the server and not passed by the client)