### PR TITLE
[no-issue] Move nestjs deps to dev and peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "test:cov": "jest --coverage"
   },
   "dependencies": {
-    "@nestjs/common": "^7.4.4",
-    "@nestjs/core": "^7.5.1",
-    "@nestjs/microservices": "^7.5.5",
-    "@nestjs/platform-express": "^7.5.5",
     "axios": "^0.21.1",
     "express": "^4.17.1",
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
+    "@nestjs/common": "^7.4.4",
+    "@nestjs/core": "^7.5.1",
+    "@nestjs/microservices": "^7.5.5",
+    "@nestjs/platform-express": "^7.5.5",
     "@nestjs/testing": "^7.4.4",
     "@types/express": "^4.17.3",
     "@types/jest": "^25.1.4",
@@ -37,6 +37,12 @@
     "ts-jest": "25.2.1",
     "ts-node": "8.6.2",
     "typescript": "3.8.3"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^7.4.4",
+    "@nestjs/core": "^7.5.1",
+    "@nestjs/microservices": "^7.5.5",
+    "@nestjs/platform-express": "^7.5.5"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
**What**
- Moves `nestjs` dependencies from `dependencies` in `package.json` to both `devDependencies` and `peerDependencies`.

**Why**
- added to `devDependencies` as they are needed in the tests
- added to `peerDependencies` to prevent nestjs bringing their versions of transitive dependencies and causing conflicts in `node_modules` in other apps using this lib as dependency